### PR TITLE
Feature/make tests work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.cache

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -1,7 +1,7 @@
 node ('openstack-jenkins-slave') {
 
     def openshiftHeatBranch = 'master'
-    def openshiftDeploymentAnsibleBranch = 'feature/make-new-app-tests-work-again'
+    def openshiftDeploymentAnsibleBranch = 'master'
 
     stage('code-checkout') {
         git branch:"$openshiftHeatBranch", url:"https://github.com/UKCloud/openshift-heat.git"

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -64,7 +64,6 @@ node ('openstack-jenkins-slave') {
 
     stage('DEBUG post deployment') {
         sh """#!/bin/bash
-           echo $SHELL;
            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt;
            env;
            echo $OPENSHIFT_USERNAME;

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -1,6 +1,6 @@
 node ('openstack-jenkins-slave') {
 
-    def openshiftHeatBranch = 'bugfix/friday-code-tidy-ocd'
+    def openshiftHeatBranch = 'master'
     def openshiftDeploymentAnsibleBranch = 'feature/make-new-app-tests-work-again'
 
     stage('code-checkout') {

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -65,36 +65,56 @@ node ('openstack-jenkins-slave') {
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible ; ./deploy-openshift.sh'")
     }
 
-    stage('DEBUG post deployment') {
+    /*
+        deploy-openshift changes the passwords for $OPENSHIFT_USERNAME, so we
+        need to grab the new password before we can attempt to log in.
+    */
+    stage('Collect the new passwords') {
         sh """
-           source ./openstack_rc.sh;
-           ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt;
-           env;
-           echo \$OPENSHIFT_USERNAME;
-           echo \$OPENSHIFT_PASSWORD;
+           ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt > new_passwords.txt;
         """
-        sh "echo \$SHELL"
     }
     /*
         The environment variables set by the pipeline need to be overwritten.
         The kubernetes parts of the pipeline automatically override the target
         host, so therefore need to unset them so you can deploy pods within
         the correct environment.
+
+        Obtain the new password to pass on to the tests/all.yml playbook.
     */
     stage('validate openshift deployment') {
-        sh("git clone -b $openshiftDeploymentAnsibleBranch https://github.com/UKCloud/openshift-deployment-ansible.git openshift-deployment-ansible")
-        sh("for var in \$(env | grep KUB | cut -d= -f1); do unset \$var; done; source ./openstack_rc.sh; ansible-playbook ./openshift-deployment-ansible/tests/all.yml --extra-vars \"hostIP=$bastionip\" --extra-vars OPENSHIFT_USERNAME=\"\$OPENSHIFT_USERNAME\" --extra-vars OPENSHIFT_PASSWORD=\"\$OPENSHIFT_PASSWORD\" --extra-vars server=\"https://ocp.customer2.cor00005.cna.ukcloud.com:8443\"") }
+        sh("""
+            git clone -b $openshiftDeploymentAnsibleBranch \
+                https://github.com/UKCloud/openshift-deployment-ansible.git openshift-deployment-ansible
 
+            NEW_PASSWORD=\$(grep \$OPENSHIFT_USERNAME new_passwords.txt | cut -d' ' -f2)
+
+            for var in \$(env | grep KUB | cut -d= -f1); do
+                unset \$var;
+            done;
+            source ./openstack_rc.sh;
+            ansible-playbook ./openshift-deployment-ansible/tests/all.yml \
+                --extra-vars \"hostIP=$bastionip\" \
+                --extra-vars OPENSHIFT_USERNAME=\"\$OPENSHIFT_USERNAME\" \
+                --extra-vars OPENSHIFT_PASSWORD=\"\$NEW_PASSWORD\" \
+                --extra-vars server=\"https://ocp.customer2.cor00005.cna.ukcloud.com:8443\"
+        """)
+    }
+
+    /*
+        Test user creation works (using a randomly-generated password)
+    */
     stage('validate openshift user creation') {
-        sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser ghfRTgg543kjsbf687UFHVJBc654c'")
-        sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'oc login https://ocp.customer2.cor00005.cna.ukcloud.com:8443 --insecure-skip-tls-verify=true -u testUser -p ghfRTgg543kjsbf687UFHVJBc654c'")
+        sh("""
+            RANDOM_PASSWORD=\$(openssl rand -base64 20 | cut -d= -f1);
 
-        /* reset the password to something random */
-        sh """
-            new_password=\$(openssl rand -base64 20 | cut -d= -f1);
-            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser \$new_password'")
+            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
+                'cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser \$RANDOM_PASSWORD'
 
-        """
+            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
+                'oc login https://ocp.customer2.cor00005.cna.ukcloud.com:8443 --insecure-skip-tls-verify=true -u testUser -p \$RANDOM_PASSWORD'
+        """)
+
 
     }
 

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -1,6 +1,6 @@
 node ('openstack-jenkins-slave') {
 
-    def openshiftHeatBranch = 'master'
+    def openshiftHeatBranch = 'bugfix/friday-code-tidy-ocd'
     def openshiftDeploymentAnsibleBranch = 'feature/make-new-app-tests-work-again'
 
     stage('code-checkout') {
@@ -112,10 +112,10 @@ node ('openstack-jenkins-slave') {
             RANDOM_PASSWORD=\$(openssl rand -base64 20 | cut -d= -f1);
 
             ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
-                'cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser \$RANDOM_PASSWORD'
+                "cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser \$RANDOM_PASSWORD"
 
             ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
-                'oc login https://ocp.customer2.cor00005.cna.ukcloud.com:8443 --insecure-skip-tls-verify=true -u testUser -p \$RANDOM_PASSWORD'
+                "oc login https://ocp.customer2.cor00005.cna.ukcloud.com:8443 --insecure-skip-tls-verify=true -u testUser -p \$RANDOM_PASSWORD"
         """)
 
 

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -56,14 +56,26 @@ node ('openstack-jenkins-slave') {
         sh("scp -o StrictHostKeyChecking=no -i id_rsa_jenkins id_rsa_jenkins cloud-user@$bastionip:")
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'chmod 600 id_rsa_jenkins'")
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible ; git checkout $openshiftDeploymentAnsibleBranch'")
-
     }
 
     stage('deploy openshift') {
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible ; ./deploy-openshift.sh'")
     }
 
-    /* The environment variables set by the pipeline need to be overwritten. The kubernetes of the pipeline automatically override the target host, so therefore need to unset them so you can deploy pods within the correct environment.
+    stage('DEBUG post deployment') {
+        sh """#!/bin/bash
+           echo $SHELL;
+           ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt;
+           env;
+           echo $OPENSHIFT_USERNAME;
+           echo $OPENSHIFT_PASSWORD;
+        """
+    }
+    /*
+        The environment variables set by the pipeline need to be overwritten.
+        The kubernetes parts of the pipeline automatically override the target
+        host, so therefore need to unset them so you can deploy pods within
+        the correct environment.
     */
     stage('validate openshift deployment') {
         sh("git clone -b $openshiftDeploymentAnsibleBranch https://github.com/UKCloud/openshift-deployment-ansible.git openshift-deployment-ansible")

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -52,7 +52,10 @@ node ('openstack-jenkins-slave') {
     }
 
     stage('checkout openshift deployment code') {
-        /* openshift-deplyment-ansible is cloned on the Bastion Host via HEAT, so we don't need to clone it here */
+        /*
+           openshift-deplyment-ansible is cloned on the Bastion Host via
+           HEAT, so we don't need to clone it here
+        */
         sh("scp -o StrictHostKeyChecking=no -i id_rsa_jenkins id_rsa_jenkins cloud-user@$bastionip:")
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'chmod 600 id_rsa_jenkins'")
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible ; git checkout $openshiftDeploymentAnsibleBranch'")
@@ -63,7 +66,8 @@ node ('openstack-jenkins-slave') {
     }
 
     stage('DEBUG post deployment') {
-        sh """#!/bin/bash
+        sh """
+           source ./openstack_rc.sh;
            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt;
            env;
            echo $OPENSHIFT_USERNAME;
@@ -78,11 +82,19 @@ node ('openstack-jenkins-slave') {
     */
     stage('validate openshift deployment') {
         sh("git clone -b $openshiftDeploymentAnsibleBranch https://github.com/UKCloud/openshift-deployment-ansible.git openshift-deployment-ansible")
-        sh("for var in \$(export | grep KUB | awk '{ print \$2 }' | sed 's/\\=.*//g'); do unset \$var; done; source ./openstack_rc.sh ; ansible-playbook ./openshift-deployment-ansible/tests/all.yml --extra-vars \"hostIP=$bastionip\" --extra-vars OPENSHIFT_USERNAME=\"\$OPENSHIFT_USERNAME\" --extra-vars OPENSHIFT_PASSWORD=\"\$OPENSHIFT_PASSWORD\" --extra-vars server=\"https://ocp.customer2.cor00005.cna.ukcloud.com:8443\"") }
+        sh("for var in \$(env | grep KUB | cut -d= -f1); do unset \$var; done; source ./openstack_rc.sh; ansible-playbook ./openshift-deployment-ansible/tests/all.yml --extra-vars \"hostIP=$bastionip\" --extra-vars OPENSHIFT_USERNAME=\"\$OPENSHIFT_USERNAME\" --extra-vars OPENSHIFT_PASSWORD=\"\$OPENSHIFT_PASSWORD\" --extra-vars server=\"https://ocp.customer2.cor00005.cna.ukcloud.com:8443\"") }
 
     stage('validate openshift user creation') {
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser ghfRTgg543kjsbf687UFHVJBc654c'")
         sh("ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'oc login https://ocp.customer2.cor00005.cna.ukcloud.com:8443 --insecure-skip-tls-verify=true -u testUser -p ghfRTgg543kjsbf687UFHVJBc654c'")
+
+        /* reset the password to something random */
+        sh """
+            new_password=\$(openssl rand -base64 20 | cut -d= -f1);
+            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip 'cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser \$new_password'")
+
+        """
+
     }
 
 }

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -1,7 +1,7 @@
 node ('openstack-jenkins-slave') {
 
     def openshiftHeatBranch = 'master'
-    def openshiftDeploymentAnsibleBranch = 'master'
+    def openshiftDeploymentAnsibleBranch = 'feature/make-new-app-tests-work-again'
 
     stage('code-checkout') {
         git branch:"$openshiftHeatBranch", url:"https://github.com/UKCloud/openshift-heat.git"

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -70,9 +70,10 @@ node ('openstack-jenkins-slave') {
            source ./openstack_rc.sh;
            ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt;
            env;
-           echo $OPENSHIFT_USERNAME;
-           echo $OPENSHIFT_PASSWORD;
+           echo \$OPENSHIFT_USERNAME;
+           echo \$OPENSHIFT_PASSWORD;
         """
+        sh "echo \$SHELL"
     }
     /*
         The environment variables set by the pipeline need to be overwritten.

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -84,6 +84,9 @@ node ('openstack-jenkins-slave') {
     */
     stage('validate openshift deployment') {
         sh("""
+            source ./openstack_rc.sh;
+            cat new_passwords.txt
+
             git clone -b $openshiftDeploymentAnsibleBranch \
                 https://github.com/UKCloud/openshift-deployment-ansible.git openshift-deployment-ansible
 
@@ -92,7 +95,7 @@ node ('openstack-jenkins-slave') {
             for var in \$(env | grep KUB | cut -d= -f1); do
                 unset \$var;
             done;
-            source ./openstack_rc.sh;
+
             ansible-playbook ./openshift-deployment-ansible/tests/all.yml \
                 --extra-vars \"hostIP=$bastionip\" \
                 --extra-vars OPENSHIFT_USERNAME=\"\$OPENSHIFT_USERNAME\" \

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -71,7 +71,7 @@ node ('openstack-jenkins-slave') {
     */
     stage('Collect the new passwords') {
         sh """
-           ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip cat /home/cloud-user/passwords.txt > new_passwords.txt;
+           scp -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip:/home/cloud-user/passwords.txt ./new_passwords.txt;
         """
     }
     /*


### PR DESCRIPTION
Lots of tweaks to the Jenkinsfile.
Fetch the passwords so we can use them in subsequent stages
use 'env' instead of 'export' to read ENV variables
shorten/wrap long lines to aid readability
use a random password for testing user creation