### PR TITLE
Add local_domain_suffix secret to more easily differentiate pipeline

### DIFF
--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -29,6 +29,7 @@ node ('openstack-jenkins-slave') {
             sh "echo export ADMIN_USERNAME=`oc get secrets openshift --template='{{ .data.adminuser }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export ADMIN_PASSWORD=`oc get secrets openshift --template='{{ .data.adminpass }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export DOMAIN_SUFFIX=`oc get secrets openshift --template='{{ .data.domainsuffix }}' | base64 --decode` | tee -a openstack_rc.sh"
+            sh "echo export LOCAL_DOMAIN_SUFFIX=`oc get secrets openshift --template='{{ .data.localdomainsuffix }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export CONTROL_PLANE_IP=`oc get secrets openshift --template='{{ .data.control_plane_ip }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export DATA_PLANE_IP=`oc get secrets openshift --template='{{ .data.data_plane_ip }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export WORKER_SMALL_SCALE=`oc get secrets openshift --template='{{ .data.worker_small_scale }}' | base64 --decode` | tee -a openstack_rc.sh"
@@ -57,6 +58,7 @@ node ('openstack-jenkins-slave') {
                 echo "parameter_defaults:"                             > environment.yaml
                 echo "  key_name: jenkins"                            >> environment.yaml
                 echo "  domain_suffix: \$DOMAIN_SUFFIX"               >> environment.yaml
+                echo "  local_domain_suffix: \$LOCAL_DOMAIN_SUFFIX"   >> environment.yaml
                 echo "  openshift_openstack_username: \$OS_USERNAME"  >> environment.yaml
                 echo "  s3_region_endpoint: \$S3_REGION_ENDPOINT"     >> environment.yaml
                 echo "  s3_access_key: \$S3_ACCESS_KEY"               >> environment.yaml

--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -54,6 +54,18 @@ read multinetwork
 echo 'Deploy extra gateway? (VRF for example) True/False'
 read deploy_extra_gateway
 
+echo 'Please enter the local domain suffix'
+read localdomainsuffix
+
+echo 'Please enter the quantity of small workers required'
+read worker_small_scale
+
+echo 'Please enter the quantity of medium workers required'
+read worker_medium_scale
+
+echo 'Please enter the quantity of large workers required'
+read worker_large_scale
+
 NAME='openshift-build-pipeline'
 SOURCE_REPOSITORY_URL='https://github.com/UKCloud/openshift-deployment-jenkins-pipeline.git'
 SOURCE_REPOSITORY_REF='master'
@@ -94,11 +106,15 @@ function setup_openstack_variables() {
         --from-literal=adminpass=$openshiftadminpass \
         --from-literal=userpass=$openshiftdemopass \
         --from-literal=domainsuffix=$domainsuffix \
+        --from-literal=localdomainsuffix=$localdomainsuffix \
         --from-literal=data_plane_ip=$dataplane_floating_ip \
         --from-literal=control_plane_ip=$controlplane_floating_ip \
         --from-literal=openshift_version=$ocp_version \
         --from-literal=multinetwork=$multinetwork \
-        --from-literal=deploy_extra_gateway=$deploy_extra_gateway
+        --from-literal=deploy_extra_gateway=$deploy_extra_gateway \
+        --from-literal=worker_small_scale=$worker_small_scale \
+        --from-literal=worker_medium_scale=$worker_medium_scale \
+        --from-literal=worker_large_scale=$worker_large_scale
 
 }
 


### PR DESCRIPTION
Tested pipeline using this configuration (referencing a different openshift-deployment-ansible branch) under openshift-deployment-jenkins-pipeline branch: feature/multi_upstream_dns