### PR TITLE
Test pipeline alterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Setup steps
 
-1. Setup this pipelines slave using the instructions from the [jenkins-openstack-slave-pipeline](https://github.com/UKCloud/jenkins-openstack-slave-pipeline) repo
+1. Setup this pipelines slave using the instructions from the [`jenkins-openstack-slave-pipeline`](https://github.com/UKCloud/jenkins-openstack-slave-pipeline) repo
 
-2. Run `./setup-ci.sh` found in this repo
+2. Setup the [`openshift-test-pipeline`](github.com/ukcloud/openshift-test-pipeline) using the command `python run.py setup_pipeline --project=build-openshift`
 
-3. Setup the [`openshift-test-pipeline`](github.com/ukcloud/openshift-test-pipeline) using the command `python run.py setup_pipeline --project=build-openshift`
+3. Run `./setup-ci.sh` found in this repo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-To execute, run the following:
-```
-./setup-ci.sh
-```
+## Setup steps
+
+1. Setup this pipelines slave using the instructions from the [jenkins-openstack-slave-pipeline](https://github.com/UKCloud/jenkins-openstack-slave-pipeline) repo
+
+2. Run `./setup-ci.sh` found in this repo
+
+3. Setup the [`openshift-test-pipeline`](github.com/ukcloud/openshift-test-pipeline) using the command `python run.py setup_pipeline --project=build-openshift`

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -168,6 +168,7 @@ node ('openstack-jenkins-slave') {
                 SSHKEY needs to be base64 encoded for this step.
             */
             sh("""
+                source ./openstack_rc.sh;
                 SSH_KEY=\$(echo \$(cat id_rsa_jenkins | base64 | tr -d '\n'))
                 ENV_VARS=\"env:
                    - name: \'USERNAME\'

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -2,7 +2,7 @@ node ('openstack-jenkins-slave') {
     try {
         def openshiftHeatBranch = 'v3.11'
 
-        slackSend color: 'good', message: "[openshift-build-pipeline started: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
+        slackSend color: 'good', message: "[openshift-build-pipeline started: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.BUILD_URL})"
 
         stage('code-checkout') {
             git branch:"$openshiftHeatBranch", url:"https://github.com/UKCloud/openshift-heat.git"
@@ -195,10 +195,10 @@ node ('openstack-jenkins-slave') {
 
     } catch (e) {
         //If there was an exception thrown, the build failed
-        slackSend color: '#c2001f', message: "[openshift-build-pipeline failed :sad_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
+        slackSend color: '#c2001f', message: "[openshift-build-pipeline failed :sad_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.BUILD_URL})"
         throw e
     } finally {
         // Success or failure, always send notifications
-        slackSend color: '#7ea8c8', message: "[openshift-build-pipeline finished: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
+        slackSend color: '#7ea8c8', message: "[openshift-build-pipeline finished: JOB_"
     }
 }

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -193,8 +193,8 @@ node ('openstack-jenkins-slave') {
 
         stage('Check Jenkins test-pipeline has finished') {
             sh("""
-                VERSION=$(oc get bc/openshift-test-pipeline -n test-pipeline --template="{{.status.lastVersion}}")
-                PHASE=$(oc get build openshift-test-pipeline-\$VERSION -n test-pipeline --template="{{.status.phase}}")
+                VERSION=\$(oc get bc/openshift-test-pipeline -n test-pipeline --template="{{.status.lastVersion}}")
+                PHASE=\$(oc get build openshift-test-pipeline-\$VERSION -n test-pipeline --template="{{.status.phase}}")
                 while [ \$PHASE -ne "Complete" ]; do
                     # Check that the build status isn't either Failed or Cancelled.
                     ACCEPTABLE=(Failed Cancelled)

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -2,7 +2,7 @@ node ('openstack-jenkins-slave') {
     try {
         def openshiftHeatBranch = 'v3.11'
 
-        slackSend color: 'good', message: "[openshift-build-pipeline started: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.BUILD_URL})"
+        slackSend color: 'good', message: "openshift-build-pipeline started: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER} - <${env.BUILD_URL}|Jenkins build URL>"
 
         stage('code-checkout') {
             git branch:"$openshiftHeatBranch", url:"https://github.com/UKCloud/openshift-heat.git"
@@ -195,10 +195,10 @@ node ('openstack-jenkins-slave') {
 
     } catch (e) {
         //If there was an exception thrown, the build failed
-        slackSend color: '#c2001f', message: "[openshift-build-pipeline failed :sad_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.BUILD_URL})"
+        slackSend color: '#c2001f', message: "openshift-build-pipeline failed :sad_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER} - <${env.BUILD_URL}|Jenkins build URL>"
         throw e
     } finally {
         // Success or failure, always send notifications
-        slackSend color: '#7ea8c8', message: "[openshift-build-pipeline finished: JOB_"
+        slackSend color: '#7ea8c8', message: "openshift-build-pipeline finished: - <${env.BUILD_URL}|Jenkins build URL>"
     }
 }

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -193,8 +193,8 @@ node ('openstack-jenkins-slave') {
 
         stage('Check Jenkins test-pipeline has finished') {
             sh("""
-                VERSION=\$(oc get bc/openshift-test-pipeline -n test-pipeline --template="{{.status.lastVersion}}")
-                PHASE=\$(oc get build openshift-test-pipeline-\$VERSION -n test-pipeline --template="{{.status.phase}}")
+                VERSION=\$(oc get bc/openshift-test-pipeline --template="{{.status.lastVersion}}")
+                PHASE=\$(oc get build openshift-test-pipeline-\$VERSION --template="{{.status.phase}}")
                 while [ \$PHASE -ne "Complete" ]; do
                     # Check that the build status isn't either Failed or Cancelled.
                     ACCEPTABLE=(Failed Cancelled)

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -171,23 +171,23 @@ node ('openstack-jenkins-slave') {
                 source ./openstack_rc.sh;
                 SSH_KEY=\$(echo \$(cat id_rsa_jenkins | base64 | tr -d '\n'))
                 ENV_VARS=\"env:
-                   - name: \'USERNAME\'
-                     value: \'\$OPENSHIFT_USERNAME\'
-                   - name: \'USERPASS\'
-                     value: \'\$OPENSHIFT_PASSWORD\'
-                   - name: \'ADMINUSER\'
-                     value: \'\$ADMIN_USERNAME\'
-                   - name: \'ADMINPASS\'
-                     value: \'\$ADMIN_PASSWORD\'
-                   - name: \'BASTIONIP\'
-                     value: \'$bastionip\'
-                   - name: \'DOMAINSUFFIX\'
-                     value: \'\$DOMAIN_SUFFIX\'
-                   - name: \'MULTINETWORK\'
-                     value: \'\$MULTINETWORK\'
-                   - name: \'SSHKEY\'
-                     value: \'\$SSH_KEY\'\"
-                curl -H \"Content-Type: application/yaml\" -d \"\$ENV_VARS\" -X \"POST\" \"\$WEBHOOK_URL\"
+                   - name: 'USERNAME'
+                     value: '\$OPENSHIFT_USERNAME'
+                   - name: 'USERPASS'
+                     value: '\$OPENSHIFT_PASSWORD'
+                   - name: 'ADMINUSER'
+                     value: '\$ADMIN_USERNAME'
+                   - name: 'ADMINPASS'
+                     value: '\$ADMIN_PASSWORD'
+                   - name: 'BASTIONIP'
+                     value: '$bastionip'
+                   - name: 'DOMAINSUFFIX'
+                     value: '\$DOMAIN_SUFFIX'
+                   - name: 'MULTINETWORK'
+                     value: '\$MULTINETWORK'
+                   - name: 'SSHKEY'
+                     value: '\$SSH_KEY'\"
+                curl -H "Content-Type: application/yaml" -d "\$ENV_VARS" -X "POST" \$WEBHOOK_URL
             """)
         }
 

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -193,16 +193,17 @@ node ('openstack-jenkins-slave') {
 
         stage('Check Jenkins test-pipeline has finished') {
             sh("""
-                REQUEST=$(curl "https://jenkins-test-pipeline.\$DOMAIN_SUFFIX/job/test-pipeline/job/test-pipeline-openshift-test-pipeline/lastBuild/api/json?tree=result" | jq ".result")
-                while [ \$REQUEST -ne "SUCCESS" ]; do
-                    # Check that the build status isn't either FAILURE or ABORTED.
-                    ACCEPTABLE=(FAILURE ABORTED)
-                    if [[ \$ACCEPTABLE[@] =~ \$REQUEST ]]; then
+                VERSION=$(oc get bc/openshift-test-pipeline -n test-pipeline --template="{{.status.lastVersion}}")
+                PHASE=$(oc get build openshift-test-pipeline-\$VERSION -n test-pipeline --template="{{.status.phase}}")
+                while [ \$PHASE -ne "Complete" ]; do
+                    # Check that the build status isn't either Failed or Cancelled.
+                    ACCEPTABLE=(Failed Cancelled)
+                    if [[ \$ACCEPTABLE[@] =~ \$PHASE ]]; then
                         echo "Test-pipeline failed!" 1>&2
                         exit 1
                     fi
                     sleep 10
-                    \$REQUEST
+                    \$PHASE
                 done
             """)
         }

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -2,7 +2,7 @@ node ('openstack-jenkins-slave') {
     try {
         def openshiftHeatBranch = 'v3.11'
 
-        slackSend color: 'good', message: "Pipeline build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
+        slackSend color: 'good', message: "[openshift-build-pipeline build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}](${env.JOB_URL})"
 
         stage('code-checkout') {
             git branch:"$openshiftHeatBranch", url:"https://github.com/UKCloud/openshift-heat.git"
@@ -195,10 +195,10 @@ node ('openstack-jenkins-slave') {
 
     } catch (e) {
         //If there was an exception thrown, the build failed
-        slackSend color: '#c2001f', message: "Pipeline failed :("
+        slackSend color: '#c2001f', message: "[openshift-build-pipeline failed :sad_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
         throw e
     } finally {
         // Success or failure, always send notifications
-        slackSend color: '#7ea8c8', message: "Pipeline finished"
+        slackSend color: '#7ea8c8', message: "[openshift-build-pipeline finished :thumbs_up_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
     }
 }

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -55,6 +55,7 @@ node ('openstack-jenkins-slave') {
             sh "echo export REG_PASSWORD=`oc get secrets openshift --template='{{ .data.registry_password }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export VAULT_PASSWORD=`oc get secrets openshift --template='{{ .data.ansible_vault_password }}' | base64 --decode` | tee -a openstack_rc.sh"
             sh "echo export ANSIBLE_BRANCH=`oc get secrets openshift --template='{{ .data.ansible_branch }}' | base64 --decode` | tee -a openstack_rc.sh"
+            sh "echo export WEBHOOK_URL=`oc get secrets openshift --template='{{ .data.webhook_url}}' | base64 --decode` | tee -a openstack_rc.sh"
         }
 
         stage('cleanup HEAT environment') {
@@ -123,6 +124,7 @@ node ('openstack-jenkins-slave') {
                 echo "    bastion_ip: "10.2.1.101""                                       >> environment.yaml
                 echo "    service_subnet: "10.2.1.240/29""                                >> environment.yaml
                 echo "  ansible_vault_password: \$VAULT_PASSWORD"                         >> environment.yaml
+                echo "  webhook_url: \$WEBHOOK_URL"                                       >> environment.yaml
             ''')
             sh('cat environment.yaml')
             sh('cat rhel_reg_creds.yaml')
@@ -159,70 +161,36 @@ node ('openstack-jenkins-slave') {
             """)
         }
 
-        stage('validate openshift deployment') {
+        stage('Start openshift-test-pipeline') {
+            /*
+                Trigger pipeline build via webhook.
+                Provide environment variables.
+                SSHKEY needs to be base64 encoded for this step.
+            */
             sh("""
-                source ./openstack_rc.sh;
-
-                ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip "ansible-playbook -i /usr/share/ansible/openshift-deployment-ansible/openshift-ansible-hosts /usr/share/ansible/openshift-deployment-ansible/tests/all.yml \
-                    --extra-vars OPENSHIFT_USERNAME=\"\$OPENSHIFT_USERNAME\" \
-                    --extra-vars OPENSHIFT_PASSWORD=\"\$OPENSHIFT_PASSWORD\" \
-                    --extra-vars ADMIN_USERNAME=\"\$ADMIN_USERNAME\" \
-                    --extra-vars ADMIN_PASSWORD=\"\$ADMIN_PASSWORD\" \
-                    --extra-vars domainSuffix=\"\$DOMAIN_SUFFIX\"
+                SSH_KEY=\$(echo \$(cat id_rsa_jenkins | base64 | tr -d '\n'))
+                ENV_VARS=\"env:
+                   - name: \'USERNAME\'
+                     value: \'\$OPENSHIFT_USERNAME\'
+                   - name: \'USERPASS\'
+                     value: \'\$OPENSHIFT_PASSWORD\'
+                   - name: \'ADMINUSER\'
+                     value: \'\$ADMIN_USERNAME\'
+                   - name: \'ADMINPASS\'
+                     value: \'\$ADMIN_PASSWORD\'
+                   - name: \'BASTIONIP\'
+                     value: \'$bastionip\'
+                   - name: \'DOMAINSUFFIX\'
+                     value: \'\$DOMAIN_SUFFIX\'
+                   - name: \'MULTINETWORK\'
+                     value: \'\$MULTINETWORK\'
+                   - name: \'SSHKEY\'
+                     value: \'\$SSH_KEY\'\"
+                curl -H \"Content-Type: application/yaml\" -d \"\$ENV_VARS\" -X \"POST\" \"\$WEBHOOK_URL\"
             """)
         }
-
-        /*
-            Load tests for cluster using Locust.
-        */
-        stage('openshift load testing') {
-            sh("""
-                source ./openstack_rc.sh;
-                ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
-                    "ansible-playbook -i /usr/share/ansible/openshift-deployment-ansible/openshift-ansible-hosts /home/cloud-user/openshift-tooling/locust/locust_setup.yaml --extra-vars domainSuffix=\"\$DOMAIN_SUFFIX\""
-            """)
-        }
-
-
-
-        stage('validate cluster cronjobs') {
-            sh("""
-                source ./openstack_rc.sh;
-
-                ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip "ansible-playbook -i /usr/share/ansible/openshift-deployment-ansible/openshift-ansible-hosts /usr/share/ansible/openshift-deployment-ansible/backup.yml";
-
-                ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip "ansible-playbook -v -i /usr/share/ansible/openshift-deployment-ansible/openshift-ansible-hosts /usr/share/ansible/openshift-deployment-ansible/tools/playbooks/docker-prune.yaml";
-                
-                if [ \"\$MULTINETWORK\" = true ]; then ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip "ansible-playbook -i /usr/share/ansible/openshift-deployment-ansible/openshift-ansible-hosts /usr/share/ansible/openshift-deployment-ansible/tools/playbooks/squid-whitelist.yaml"; fi
-            """)
-        }
-
-
-        /*
-            Test user creation works (using a randomly-generated password)
-        */
-        stage('validate openshift user creation') {
-            sh("""
-                source ./openstack_rc.sh;
-                RANDOM_PASSWORD=\$(openssl rand -base64 20 | cut -d= -f1);
-
-                ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
-                    "cd /usr/share/ansible/openshift-deployment-ansible/tools/ ; ./create-user.sh testUser \$RANDOM_PASSWORD"
-
-                ssh -o StrictHostKeyChecking=no -i id_rsa_jenkins cloud-user@$bastionip \
-                    "oc login https://ocp.\$DOMAIN_SUFFIX:8443 --insecure-skip-tls-verify=true -u testUser -p \$RANDOM_PASSWORD"
-            """)
-        }
-
 
         //slackSend color: 'good', message: "Pipeline build Completed Successfully: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
-
-       stage('Cleanup HEAT deployment on successful deployment') {
-            sh("""
-                source ./openstack_rc.sh;
-                openstack stack delete openshift-\$OS_PROJECT_NAME --wait --yes
-            """)
-        }
 
     } catch (e) {
         //If there was an exception thrown, the build failed

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -191,6 +191,22 @@ node ('openstack-jenkins-slave') {
             """)
         }
 
+        stage('Check Jenkins test-pipeline has finished') {
+            sh("""
+                REQUEST=$(curl "https://jenkins-test-pipeline.\$DOMAIN_SUFFIX/job/test-pipeline/job/test-pipeline-openshift-test-pipeline/lastBuild/api/json?tree=result" | jq ".result")
+                while [ \$REQUEST -ne "SUCCESS" ]; do
+                    # Check that the build status isn't either FAILURE or ABORTED.
+                    ACCEPTABLE=(FAILURE ABORTED)
+                    if [[ \$ACCEPTABLE[@] =~ \$REQUEST ]]; then
+                        echo "Test-pipeline failed!" 1>&2
+                        exit 1
+                    fi
+                    sleep 10
+                    \$REQUEST
+                done
+            """)
+        }
+
         //slackSend color: 'good', message: "Pipeline build Completed Successfully: ${env.JOB_NAME} ${env.BUILD_NUMBER}"
 
     } catch (e) {

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -199,6 +199,6 @@ node ('openstack-jenkins-slave') {
         throw e
     } finally {
         // Success or failure, always send notifications
-        slackSend color: '#7ea8c8', message: "[openshift-build-pipeline finished :thumbs_up_parrot: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
+        slackSend color: '#7ea8c8', message: "[openshift-build-pipeline finished: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
     }
 }

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -199,7 +199,7 @@ node ('openstack-jenkins-slave') {
             sh("""
                 VERSION=\$(oc get bc/openshift-test-pipeline --template="{{.status.lastVersion}}")
                 PHASE=\$(oc get build openshift-test-pipeline-\$VERSION --template="{{.status.phase}}")
-                while [ "\$PHASE" -ne "Complete" ]; do
+                while [ "\$PHASE" != "Complete" ]; do
                     # Check that the build status isn't either Failed or Cancelled.
                     ACCEPTABLE=(Failed Cancelled)
                     if [[ "\$ACCEPTABLE[@]" =~ "\$PHASE" ]]; then

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -2,7 +2,7 @@ node ('openstack-jenkins-slave') {
     try {
         def openshiftHeatBranch = 'v3.11'
 
-        slackSend color: 'good', message: "[openshift-build-pipeline build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}](${env.JOB_URL})"
+        slackSend color: 'good', message: "[openshift-build-pipeline started: Job name: ${env.JOB_NAME} Build number: ${env.BUILD_NUMBER}](${env.JOB_URL})"
 
         stage('code-checkout') {
             git branch:"$openshiftHeatBranch", url:"https://github.com/UKCloud/openshift-heat.git"

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -199,10 +199,10 @@ node ('openstack-jenkins-slave') {
             sh("""
                 VERSION=\$(oc get bc/openshift-test-pipeline --template="{{.status.lastVersion}}")
                 PHASE=\$(oc get build openshift-test-pipeline-\$VERSION --template="{{.status.phase}}")
-                while [ \$PHASE -ne "Complete" ]; do
+                while [ "\$PHASE" -ne "Complete" ]; do
                     # Check that the build status isn't either Failed or Cancelled.
                     ACCEPTABLE=(Failed Cancelled)
-                    if [[ \$ACCEPTABLE[@] =~ \$PHASE ]]; then
+                    if [[ "\$ACCEPTABLE[@]" =~ "\$PHASE" ]]; then
                         echo "Test-pipeline failed!" 1>&2
                         exit 1
                     fi

--- a/jenkins-pipelines/openshift/Jenkinsfile
+++ b/jenkins-pipelines/openshift/Jenkinsfile
@@ -197,9 +197,12 @@ node ('openstack-jenkins-slave') {
 
         stage('Check Jenkins test-pipeline has finished') {
             sh("""
-                VERSION=\$(oc get bc/openshift-test-pipeline --template="{{.status.lastVersion}}")
-                PHASE=\$(oc get build openshift-test-pipeline-\$VERSION --template="{{.status.phase}}")
-                while [ "\$PHASE" != "Complete" ]; do
+                getphase() {
+                    VERSION=\$(oc get bc/openshift-test-pipeline --template="{{.status.lastVersion}}")
+                    PHASE=\$(oc get build openshift-test-pipeline-\$VERSION --template="{{.status.phase}}")
+                }
+                getphase
+                while [ \$PHASE != "Complete" ]; do
                     # Check that the build status isn't either Failed or Cancelled.
                     ACCEPTABLE=(Failed Cancelled)
                     if [[ "\$ACCEPTABLE[@]" =~ "\$PHASE" ]]; then
@@ -207,7 +210,7 @@ node ('openstack-jenkins-slave') {
                         exit 1
                     fi
                     sleep 10
-                    \$PHASE
+                    getphase
                 done
             """)
         }

--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -114,6 +114,9 @@ read ansible_branch
 echo 'Please provide the ansible vault password to decrypt deploy key'
 read ansible_vault_password
 
+echo 'Please provide the webhook url for the openshift-test-pipeline'
+read webhook_url
+
 echo 'Please provide the auth URL for the openstack environment (v3)'
 read OPENSTACK_AUTH_URL
 
@@ -187,7 +190,8 @@ function setup_openstack_variables() {
         --from-literal=registry_user=$registry_user \
         --from-literal=registry_password=$registry_password \
         --from-literal=ansible_branch=$ansible_branch \
-        --from-literal=ansible_vault_password=$ansible_vault_password
+        --from-literal=ansible_vault_password=$ansible_vault_password \
+        --from-literal=webhook_url=$webhook_url
 
 }
 


### PR DESCRIPTION
# Changes
* Added the retrieval of the `webhook_url` from the secret and export it. Which is then sourced by `openstack_rc.sh`.
* Added an echo to see what the `webhook_url` value is set to (for debugging purposes).
* Removed all test stages, as they are now done in the by the `openshift-test-pipeline`
* Added a new stage to prepare the required variables and YAML payload to send as the webhook body (to trigger the `openshift-test-pipeline`).
* Removed end stage of cleanup as we don't want the openstack project to be deleted before the tests pipeline has completed.
* Added input for the `webhook_url` in `setup-ci.sh`.
* Edited ReadME.md for setup steps with test-pipeline.
## Prerequisites:
* An `openshift-test-pipeline` has been deployed.
* You have added `webhook_url` to the `openshift` secret with the value being the generic webhook url to trigger the `openshift-test-pipeline`. **EDIT**: This is now prompted in the `setup-ci.sh` script.


