### PR TITLE
Automate webhook creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ To execute, run the following:
 ```
 ./setup-ci.sh
 ```
+
+## Webhook Creation
+
+In order to create a webhook via the Github API, your account must have admin access to the repository your trying to create a webhook for.
+Furthermore, you must generate a [personal access token](https://github.com/settings/tokens) and grant it `admin:repo_hook` permissions.

--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -217,4 +217,3 @@ function configure_openshift_githooks() {
 setup_openshift_deployment_jenkins_pipeline
 setup_openstack_variables
 configure_openshift_githooks
-

--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -196,7 +196,7 @@ function configure_openshift_githooks() {
     # Prompt the user for required information
     read -p "Enter Github username: " githubUsername
     read -s -p "Enter Github personal access token: " accessToken
-    read -p "Enter repository owner and repository name (UKCloud/openshift-deployment-ansible): " ownerRepo
+    read -p "Enter organisation/user and repository name eg: UKCloud/openshift-deployment-ansible: " ownerRepo
 
     # Make request to the Github V3 API to create the Github webhook
     curl -u $githubUsername:$accessToken -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$ownerRepo/hooks \

--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -192,9 +192,12 @@ function setup_openstack_variables() {
 }
 
 function configure_openshift_githooks() {
-    # TODO: Automate webhook creation and updates via the github API
     gitHook=$(oc describe bc ${NAME} | grep -A1 'Webhook GitHub' | grep URL | awk '{print $NF}')
-    echo "Add a github webhook for the following URL to trigger automated builds of the Jenkins pipeline, $gitHook"
+    read -p "Enter Github username: " githubUsername
+    read -ps "Enter Github personal access token: " accessToken
+    read -p "Enter repository owner and repository name (UKCloud/openshift-deployment-ansible): " ownerRepo
+    jsonPayload = '{"name": "JenkinsPipeline", "active": true, "events": ["pull_request"], "config": {"url": $gitHook, "content_type": "json", "insecure_ssl": "0"}}'
+    curl -u $githubUsername:$accessToken -H "Accept: application/vnd.github.v3+json" -d $jsonPayload -X "POST" "https://api.github.com/repos/$ownerRepo/hooks"
 }
 
 setup_openshift_deployment_jenkins_pipeline


### PR DESCRIPTION
This PR implements automated webhook creation via the Github v3 API.

* The function `configure_openshift_githooks` now prompts for the Github username, personal access token and `repo-owner/repo-name`.

* Prerequisites for the webhook creation have been added to README.md.